### PR TITLE
CI/CDパイプラインとv0.1.0リリースワークフロー

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+version: 2
+updates:
+  - package-ecosystem: "cargo"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    reviewers:
+      - "takemo101"
+    labels:
+      - "dependencies"
+      - "rust"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,234 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+
+env:
+  RUST_BACKTRACE: 1
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build-release:
+    name: Build Release (${{ matrix.target }})
+    runs-on: macos-latest
+    strategy:
+      matrix:
+        target:
+          - x86_64-apple-darwin
+          - aarch64-apple-darwin
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.target }}
+
+      - name: Build release
+        run: cargo build --release --target ${{ matrix.target }}
+
+      - name: Strip binary
+        run: strip target/${{ matrix.target }}/release/pomodoro
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: pomodoro-${{ matrix.target }}
+          path: target/${{ matrix.target }}/release/pomodoro
+
+  create-universal-binary:
+    name: Create Universal Binary
+    runs-on: macos-latest
+    needs: build-release
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Download x86_64 binary
+        uses: actions/download-artifact@v4
+        with:
+          name: pomodoro-x86_64-apple-darwin
+          path: ./artifacts/x86_64
+
+      - name: Download aarch64 binary
+        uses: actions/download-artifact@v4
+        with:
+          name: pomodoro-aarch64-apple-darwin
+          path: ./artifacts/aarch64
+
+      - name: Create universal binary
+        run: |
+          lipo -create \
+            ./artifacts/x86_64/pomodoro \
+            ./artifacts/aarch64/pomodoro \
+            -output ./pomodoro-universal
+
+      - name: Verify universal binary
+        run: |
+          lipo -info ./pomodoro-universal
+          file ./pomodoro-universal
+
+      - name: Code sign binary
+        if: env.MACOS_CERTIFICATE != ''
+        env:
+          MACOS_CERTIFICATE: ${{ secrets.MACOS_CERTIFICATE }}
+          MACOS_CERTIFICATE_PWD: ${{ secrets.MACOS_CERTIFICATE_PWD }}
+          KEYCHAIN_PASSWORD: ${{ secrets.KEYCHAIN_PASSWORD }}
+          SIGNING_IDENTITY: ${{ secrets.MACOS_SIGNING_IDENTITY }}
+        run: |
+          # キーチェーン作成
+          security create-keychain -p "$KEYCHAIN_PASSWORD" build.keychain
+          security default-keychain -s build.keychain
+          security unlock-keychain -p "$KEYCHAIN_PASSWORD" build.keychain
+          security set-keychain-settings -t 3600 -u build.keychain
+
+          # 証明書インポート
+          echo "$MACOS_CERTIFICATE" | base64 --decode > certificate.p12
+          security import certificate.p12 -k build.keychain -P "$MACOS_CERTIFICATE_PWD" -T /usr/bin/codesign
+
+          # 証明書の信頼設定
+          security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k "$KEYCHAIN_PASSWORD" build.keychain
+
+          # コード署名
+          codesign --force --sign "$SIGNING_IDENTITY" \
+            --options runtime \
+            --timestamp \
+            ./pomodoro-universal
+
+          # 署名検証
+          codesign --verify --verbose ./pomodoro-universal
+          spctl --assess --verbose ./pomodoro-universal
+
+      - name: Create tarball
+        run: |
+          tar -czf pomodoro-universal-macos.tar.gz pomodoro-universal
+          shasum -a 256 pomodoro-universal-macos.tar.gz > pomodoro-universal-macos.tar.gz.sha256
+
+      - name: Upload universal binary
+        uses: actions/upload-artifact@v4
+        with:
+          name: pomodoro-universal
+          path: |
+            pomodoro-universal-macos.tar.gz
+            pomodoro-universal-macos.tar.gz.sha256
+
+  create-github-release:
+    name: Create GitHub Release
+    runs-on: macos-latest
+    needs: create-universal-binary
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Download universal binary
+        uses: actions/download-artifact@v4
+        with:
+          name: pomodoro-universal
+          path: ./release
+
+      - name: Extract version
+        id: version
+        run: |
+          VERSION=${GITHUB_REF#refs/tags/v}
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+
+      - name: Create Release
+        uses: softprops/action-gh-release@v1
+        with:
+          name: Release v${{ steps.version.outputs.version }}
+          body: |
+            ## ポモドーロタイマーCLI v${{ steps.version.outputs.version }}
+
+            ### インストール方法
+
+            #### Homebrew（推奨）
+            ```bash
+            brew tap takemo101/pomodoro
+            brew install pomodoro
+            ```
+
+            #### 手動インストール
+            ```bash
+            # ダウンロード
+            curl -LO https://github.com/${{ github.repository }}/releases/download/v${{ steps.version.outputs.version }}/pomodoro-universal-macos.tar.gz
+
+            # SHA256チェックサム検証
+            curl -LO https://github.com/${{ github.repository }}/releases/download/v${{ steps.version.outputs.version }}/pomodoro-universal-macos.tar.gz.sha256
+            shasum -a 256 -c pomodoro-universal-macos.tar.gz.sha256
+
+            # 解凍
+            tar -xzf pomodoro-universal-macos.tar.gz
+
+            # インストール
+            sudo mv pomodoro-universal /usr/local/bin/pomodoro
+            sudo chmod +x /usr/local/bin/pomodoro
+            ```
+
+            ### 動作確認
+            ```bash
+            pomodoro --version
+            ```
+
+            ### 変更内容
+            - 詳細は [CHANGELOG.md](https://github.com/${{ github.repository }}/blob/main/CHANGELOG.md) を参照
+
+            ### システム要件
+            - macOS 12 (Monterey) 以降
+            - Intel Mac または Apple Silicon Mac
+          files: |
+            ./release/pomodoro-universal-macos.tar.gz
+            ./release/pomodoro-universal-macos.tar.gz.sha256
+          draft: false
+          prerelease: false
+
+  update-homebrew-formula:
+    name: Update Homebrew Formula
+    runs-on: macos-latest
+    needs: create-github-release
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
+    steps:
+      - name: Extract version
+        id: version
+        run: |
+          VERSION=${GITHUB_REF#refs/tags/v}
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+
+      - name: Update Homebrew formula
+        if: env.HOMEBREW_GITHUB_API_TOKEN != ''
+        env:
+          HOMEBREW_GITHUB_API_TOKEN: ${{ secrets.HOMEBREW_GITHUB_API_TOKEN }}
+        run: |
+          # Homebrew formulaリポジトリをクローン
+          git clone https://github.com/takemo101/homebrew-pomodoro.git
+          cd homebrew-pomodoro
+
+          # SHA256取得
+          SHA256=$(curl -sL https://github.com/${{ github.repository }}/releases/download/v${{ steps.version.outputs.version }}/pomodoro-universal-macos.tar.gz | shasum -a 256 | awk '{print $1}')
+
+          # Formula更新
+          cat > Formula/pomodoro.rb <<EOF
+          class Pomodoro < Formula
+            desc "macOS専用のポモドーロタイマーCLIツール"
+            homepage "https://github.com/${{ github.repository }}"
+            url "https://github.com/${{ github.repository }}/releases/download/v${{ steps.version.outputs.version }}/pomodoro-universal-macos.tar.gz"
+            sha256 "$SHA256"
+            version "${{ steps.version.outputs.version }}"
+
+            def install
+              bin.install "pomodoro-universal" => "pomodoro"
+            end
+
+            test do
+              system "#{bin}/pomodoro", "--version"
+            end
+          end
+          EOF
+
+          # コミット・プッシュ
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add Formula/pomodoro.rb
+          git commit -m "Update pomodoro to v${{ steps.version.outputs.version }}"
+          git push

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,48 @@
+.PHONY: help install build test lint clean release
+
+help: ## ヘルプを表示
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-20s\033[0m %s\n", $$1, $$2}'
+
+install: ## 依存関係をインストール
+	rustup target add x86_64-apple-darwin aarch64-apple-darwin
+	cargo install cargo-audit cargo-deny cargo-tarpaulin
+
+build: ## デバッグビルド
+	cargo build
+
+build-release: ## リリースビルド（ユニバーサルバイナリ）
+	cargo build --release --target x86_64-apple-darwin
+	cargo build --release --target aarch64-apple-darwin
+	mkdir -p target/release
+	lipo -create \
+		target/x86_64-apple-darwin/release/pomodoro \
+		target/aarch64-apple-darwin/release/pomodoro \
+		-output target/release/pomodoro-universal
+
+test: ## テスト実行
+	cargo test --all-features
+
+lint: ## Lint実行
+	cargo fmt --all -- --check
+	cargo clippy --all-targets --all-features -- -D warnings
+
+coverage: ## カバレッジ測定
+	cargo tarpaulin --out Html --all-features
+	open tarpaulin-report.html
+
+audit: ## セキュリティ監査
+	cargo audit
+	cargo deny check
+
+clean: ## ビルド成果物削除
+	cargo clean
+
+run: ## デーモン起動
+	cargo run -- daemon
+
+install-local: build-release ## ローカルにインストール
+	sudo cp target/release/pomodoro-universal /usr/local/bin/pomodoro
+	sudo chmod +x /usr/local/bin/pomodoro
+
+uninstall-local: ## ローカルからアンインストール
+	sudo rm -f /usr/local/bin/pomodoro


### PR DESCRIPTION
## 概要
Issue #15 の実装 - GitHub Actionsリリースワークフローの追加

## 変更内容

### `.github/workflows/release.yml`
- **トリガー**: タグプッシュ時（`v*.*.*` パターン）に自動実行
- **ビルド**: Intel (x86_64) と Apple Silicon (aarch64) の両アーキテクチャでリリースビルド
- **ユニバーサルバイナリ**: `lipo` で両アーキテクチャを統合
- **コード署名**: シークレット設定時のみ実行（オプショナル）
  - `MACOS_CERTIFICATE`, `MACOS_CERTIFICATE_PWD`, `KEYCHAIN_PASSWORD`, `MACOS_SIGNING_IDENTITY`
- **GitHub Release**: tarball + SHA256チェックサムを自動アップロード
- **Homebrew更新**: `HOMEBREW_GITHUB_API_TOKEN` 設定時に自動更新（オプショナル）

### `.github/dependabot.yml`
- Cargo依存関係の週次自動更新チェック
- 最大10件のPRを同時オープン

### `Makefile`
- `make build`: デバッグビルド
- `make build-release`: リリースビルド（ユニバーサルバイナリ）
- `make test`: テスト実行
- `make lint`: フォーマット/Clippy実行
- `make install-local`: ローカルインストール

## リリース手順
1. このPRをマージ
2. `git tag v0.1.0 && git push origin v0.1.0` でリリースワークフローが自動実行
3. GitHub Releasesでリリースノートを確認

## 必要なシークレット（オプショナル）
コード署名を有効にする場合:
- `MACOS_CERTIFICATE`: Base64エンコードされた.p12証明書
- `MACOS_CERTIFICATE_PWD`: 証明書パスワード
- `KEYCHAIN_PASSWORD`: 一時キーチェーン用パスワード
- `MACOS_SIGNING_IDENTITY`: 署名ID (例: "Developer ID Application: Your Name")

Homebrew自動更新を有効にする場合:
- `HOMEBREW_GITHUB_API_TOKEN`: homebrew-pomodoroリポジトリへの書き込み権限を持つトークン

Closes #15